### PR TITLE
fixed <gw:GW_HydrogeoUnit> to gw:GW_HydrogeoUnit

### DIFF
--- a/docs/examples/rdf/meta-resource-1.ttl
+++ b/docs/examples/rdf/meta-resource-1.ttl
@@ -17,7 +17,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "application/ld+json", "text/ttl" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/selfie/data/hydrogeounit/richelieu-1>
   ],
@@ -25,7 +25,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "application/vnd.geo+json", "text/html" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/service/selfie/api/collections/data/items/hydrogeounit-richelieu-1>
   ],
@@ -33,7 +33,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "application/vnd.geo+json" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/selfie/representations/richelieu-1.geojson>
   ],
@@ -41,7 +41,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "text/html" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/selfie/representations/richelieu-1.html>
   ] ;

--- a/docs/examples/rdf/meta-resource-2.ttl
+++ b/docs/examples/rdf/meta-resource-2.ttl
@@ -17,7 +17,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "application/ld+json", "text/ttl" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/selfie/data/hydrogeounit/richelieu-2>
   ],
@@ -25,7 +25,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "application/vnd.geo+json", "text/html" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/service/selfie/api/collections/data/items/hydrogeounit-richelieu-2>
   ],
@@ -33,7 +33,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "application/vnd.geo+json" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/selfie/representations/richelieu-2.geojson>
   ],
@@ -41,7 +41,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "text/html" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/selfie/representations/richelieu-2.html>
   ] ;

--- a/docs/examples/rdf/meta-resource-3.ttl
+++ b/docs/examples/rdf/meta-resource-3.ttl
@@ -17,7 +17,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "application/ld+json", "text/ttl" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/selfie/data/hydrogeounit/richelieu-3>
   ],
@@ -25,7 +25,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "application/vnd.geo+json", "text/html" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/service/selfie/api/collections/data/items/hydrogeounit-richelieu-3>
   ],
@@ -33,7 +33,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "application/vnd.geo+json" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/selfie/representations/richelieu-3.geojson>
   ],
@@ -41,7 +41,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "text/html" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/selfie/representations/richelieu-3.html>
   ] ;

--- a/docs/examples/rdf/meta-resource-4.ttl
+++ b/docs/examples/rdf/meta-resource-4.ttl
@@ -17,7 +17,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "application/ld+json", "text/ttl" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/selfie/data/hydrogeounit/richelieu-4>
   ],
@@ -25,7 +25,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "application/vnd.geo+json", "text/html" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/service/selfie/api/collections/data/items/hydrogeounit-richelieu-4>
   ],
@@ -33,7 +33,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "application/vnd.geo+json" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/selfie/representations/richelieu-4.geojson>
   ],
@@ -41,7 +41,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "text/html" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/selfie/representations/richelieu-4.html>
   ] ;

--- a/docs/examples/rdf/meta-resource-5.ttl
+++ b/docs/examples/rdf/meta-resource-5.ttl
@@ -17,7 +17,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "application/ld+json", "text/ttl" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/selfie/data/hydrogeounit/richelieu-5>
   ],
@@ -25,7 +25,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "application/vnd.geo+json", "text/html" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/service/selfie/api/collections/data/items/hydrogeounit-richelieu-5>
   ],
@@ -33,7 +33,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "application/vnd.geo+json" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/selfie/representations/richelieu-5.geojson>
   ],
@@ -41,7 +41,7 @@
     rdf:type foaf:Document ;
     dct:conformsTo <https://www.opengis.net/def/gwml2> ;
     dct:format "text/html" ;
-    foaf:primaryTopic <gw:GW_HydrogeoUnit> ;
+    foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
     schema:url <https://lab.scinfo.org.nz/selfie/representations/richelieu-5.html>
   ] ;


### PR DESCRIPTION
in ttl, <> are for URI, a prefixed resource is just gw:GW_HydrogeoUnit.  fixed in the examples