### PR TITLE
fixed url and image that should be literal strings, not resources

### DIFF
--- a/docs/examples/rdf/meta-resource-1.ttl
+++ b/docs/examples/rdf/meta-resource-1.ttl
@@ -11,7 +11,7 @@
 <https://lab.scinfo.org.nz/selfie/id/hydrogeounit/richelieu-1>
   a GW_HydrogeoUnit ;
   schema:description "The Southern St Lawrence Platform is a Hydrogeologic Unit within the Richelieu Aquifer System." ;
-  schema:image <https://www.nzc.nz/media/15483/kane-williamson_01.jpg> ;
+  schema:image "https://www.nzc.nz/media/15483/kane-williamson_01.jpg" ;
   schema:name "Hydrogeologic unit : Southern St Lawrence Platform" ;
   schema:subjectOf [
     rdf:type foaf:Document ;
@@ -43,7 +43,7 @@
     dct:format "text/html" ;
     foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
-    schema:url <https://lab.scinfo.org.nz/selfie/representations/richelieu-1.html>
+    schema:url "https://lab.scinfo.org.nz/selfie/representations/richelieu-1.html"
   ] ;
   rdfs:label "Hydrogeologic unit : Southern St Lawrence Platform"@en, "Unite hydrogeologique : Plate-forme du St-Laurent sud"@fr ;
   owl:sameAs <https://geoconnex.ca/id/hydrogeounits/Richelieu1> .

--- a/docs/examples/rdf/meta-resource-2.ttl
+++ b/docs/examples/rdf/meta-resource-2.ttl
@@ -11,7 +11,7 @@
 <https://lab.scinfo.org.nz/selfie/id/hydrogeounit/richelieu-2>
   a gw:GW_HydrogeoUnit ;
   schema:description "The Northern St Lawrence Platform is a Hydrogeologic Unit within the Richelieu Aquifer System." ;
-  schema:image <https://www.nzc.nz/media/15493/trent-boult.jpg> ;
+  schema:image "https://www.nzc.nz/media/15493/trent-boult.jpg" ;
   schema:name "Hydrogeologic unit : Northern St Lawrence Platform" ;
   schema:subjectOf [
     rdf:type foaf:Document ;
@@ -19,7 +19,7 @@
     dct:format "application/ld+json", "text/ttl" ;
     foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
-    schema:url <https://lab.scinfo.org.nz/selfie/data/hydrogeounit/richelieu-2>
+    schema:url "https://lab.scinfo.org.nz/selfie/data/hydrogeounit/richelieu-2"
   ],
   [
     rdf:type foaf:Document ;
@@ -27,7 +27,7 @@
     dct:format "application/vnd.geo+json", "text/html" ;
     foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
-    schema:url <https://lab.scinfo.org.nz/service/selfie/api/collections/data/items/hydrogeounit-richelieu-2>
+    schema:url "https://lab.scinfo.org.nz/service/selfie/api/collections/data/items/hydrogeounit-richelieu-2"
   ],
   [
     rdf:type foaf:Document ;
@@ -35,7 +35,7 @@
     dct:format "application/vnd.geo+json" ;
     foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
-    schema:url <https://lab.scinfo.org.nz/selfie/representations/richelieu-2.geojson>
+    schema:url "https://lab.scinfo.org.nz/selfie/representations/richelieu-2.geojson"
   ],
   [
     rdf:type foaf:Document ;
@@ -43,7 +43,7 @@
     dct:format "text/html" ;
     foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
-    schema:url <https://lab.scinfo.org.nz/selfie/representations/richelieu-2.html>
+    schema:url "https://lab.scinfo.org.nz/selfie/representations/richelieu-2.html"
   ] ;
   rdfs:label "Hydrogeologic unit : Northern St Lawrence Platform"@en, "Unite hydrogeologique : Plate-forme du St-Laurent nord"@fr ;
   owl:sameAs <https://geoconnex.ca/id/hydrogeounits/Richelieu2> .

--- a/docs/examples/rdf/meta-resource-3.ttl
+++ b/docs/examples/rdf/meta-resource-3.ttl
@@ -11,7 +11,7 @@
 <https://lab.scinfo.org.nz/selfie/id/hydrogeounit/richelieu-3>
   a gw:GW_HydrogeoUnit ;
   schema:description "The Appalachian External zone is a Hydrogeologic Unit within the Richelieu Aquifer System." ;
-  schema:image <https://www.nzc.nz/media/12842/kerr_headshot_2018.jpg> ;
+  schema:image "https://www.nzc.nz/media/12842/kerr_headshot_2018.jpg" ;
   schema:name "Hydrogeologic unit : Appalachian External zone" ;
   schema:subjectOf [
     rdf:type foaf:Document ;
@@ -19,7 +19,7 @@
     dct:format "application/ld+json", "text/ttl" ;
     foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
-    schema:url <https://lab.scinfo.org.nz/selfie/data/hydrogeounit/richelieu-3>
+    schema:url "https://lab.scinfo.org.nz/selfie/data/hydrogeounit/richelieu-3"
   ],
   [
     rdf:type foaf:Document ;
@@ -27,7 +27,7 @@
     dct:format "application/vnd.geo+json", "text/html" ;
     foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
-    schema:url <https://lab.scinfo.org.nz/service/selfie/api/collections/data/items/hydrogeounit-richelieu-3>
+    schema:url "https://lab.scinfo.org.nz/service/selfie/api/collections/data/items/hydrogeounit-richelieu-3"
   ],
   [
     rdf:type foaf:Document ;
@@ -35,7 +35,7 @@
     dct:format "application/vnd.geo+json" ;
     foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
-    schema:url <https://lab.scinfo.org.nz/selfie/representations/richelieu-3.geojson>
+    schema:url "https://lab.scinfo.org.nz/selfie/representations/richelieu-3.geojson"
   ],
   [
     rdf:type foaf:Document ;
@@ -43,7 +43,7 @@
     dct:format "text/html" ;
     foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
-    schema:url <https://lab.scinfo.org.nz/selfie/representations/richelieu-3.html>
+    schema:url "https://lab.scinfo.org.nz/selfie/representations/richelieu-3.html"
   ] ;
   rdfs:label "Hydrogeologic unit : Appalachian External zone"@en, "Unite hydrogeologique : Zone externe des Appalaches"@fr ;
   owl:sameAs <https://geoconnex.ca/id/hydrogeounits/Richelieu3> .

--- a/docs/examples/rdf/meta-resource-4.ttl
+++ b/docs/examples/rdf/meta-resource-4.ttl
@@ -19,7 +19,7 @@
     dct:format "application/ld+json", "text/ttl" ;
     foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
-    schema:url <https://lab.scinfo.org.nz/selfie/data/hydrogeounit/richelieu-4>
+    schema:url "https://lab.scinfo.org.nz/selfie/data/hydrogeounit/richelieu-4"
   ],
   [
     rdf:type foaf:Document ;
@@ -27,7 +27,7 @@
     dct:format "application/vnd.geo+json", "text/html" ;
     foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
-    schema:url <https://lab.scinfo.org.nz/service/selfie/api/collections/data/items/hydrogeounit-richelieu-4>
+    schema:url "https://lab.scinfo.org.nz/service/selfie/api/collections/data/items/hydrogeounit-richelieu-4"
   ],
   [
     rdf:type foaf:Document ;
@@ -35,7 +35,7 @@
     dct:format "application/vnd.geo+json" ;
     foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
-    schema:url <https://lab.scinfo.org.nz/selfie/representations/richelieu-4.geojson>
+    schema:url "https://lab.scinfo.org.nz/selfie/representations/richelieu-4.geojson"
   ],
   [
     rdf:type foaf:Document ;
@@ -43,7 +43,7 @@
     dct:format "text/html" ;
     foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
-    schema:url <https://lab.scinfo.org.nz/selfie/representations/richelieu-4.html>
+    schema:url "https://lab.scinfo.org.nz/selfie/representations/richelieu-4.html"
   ] ;
   rdfs:label "Hydrogeologic unit : Appalachian Internal zone"@en, "Unite hydrogeologique : Zone interne des Appalaches"@fr ;
   owl:sameAs <https://geoconnex.ca/id/hydrogeounits/Richelieu4> .

--- a/docs/examples/rdf/meta-resource-5.ttl
+++ b/docs/examples/rdf/meta-resource-5.ttl
@@ -11,7 +11,7 @@
 <https://lab.scinfo.org.nz/selfie/id/hydrogeounit/richelieu-5>
   a gw:GW_HydrogeoUnit ;
   schema:description "The Monteregian intrusions is a Hydrogeologic Unit within the Richelieu Aquifer System." ;
-  schema:image <https://www.nzc.nz/media/12834/bates_headshot_2018.jpg> ;
+  schema:image "https://www.nzc.nz/media/12834/bates_headshot_2018.jpg" ;
   schema:name "Hydrogeologic unit : Monteregian intrusions" ;
   schema:subjectOf [
     rdf:type foaf:Document ;
@@ -19,7 +19,7 @@
     dct:format "application/ld+json", "text/ttl" ;
     foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
-    schema:url <https://lab.scinfo.org.nz/selfie/data/hydrogeounit/richelieu-5>
+    schema:url "https://lab.scinfo.org.nz/selfie/data/hydrogeounit/richelieu-5"
   ],
   [
     rdf:type foaf:Document ;
@@ -27,7 +27,7 @@
     dct:format "application/vnd.geo+json", "text/html" ;
     foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
-    schema:url <https://lab.scinfo.org.nz/service/selfie/api/collections/data/items/hydrogeounit-richelieu-5>
+    schema:url "https://lab.scinfo.org.nz/service/selfie/api/collections/data/items/hydrogeounit-richelieu-5"
   ],
   [
     rdf:type foaf:Document ;
@@ -35,7 +35,7 @@
     dct:format "application/vnd.geo+json" ;
     foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
-    schema:url <https://lab.scinfo.org.nz/selfie/representations/richelieu-5.geojson>
+    schema:url "https://lab.scinfo.org.nz/selfie/representations/richelieu-5.geojson"
   ],
   [
     rdf:type foaf:Document ;
@@ -43,7 +43,7 @@
     dct:format "text/html" ;
     foaf:primaryTopic gw:GW_HydrogeoUnit ;
     schema:provider <https://opengeospatial.github.io/SELFIE/> ;
-    schema:url <https://lab.scinfo.org.nz/selfie/representations/richelieu-5.html>
+    schema:url "https://lab.scinfo.org.nz/selfie/representations/richelieu-5.html"
   ] ;
   rdfs:label "Hydrogeologic unit : Monteregian intrusions"@en, "Unite hydrogeologique : Intrusions Monteregiennes"@fr ;
   owl:sameAs <https://geoconnex.ca/id/hydrogeounits/Richelieu5> .


### PR DESCRIPTION
As far as I understand, schema:image and schemaLurl are not pointing to resources, but literal strings

fixed in the examples